### PR TITLE
Add supplier batch creation endpoint

### DIFF
--- a/dist/controllers/supplierBatchController.js
+++ b/dist/controllers/supplierBatchController.js
@@ -1,0 +1,69 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.createBatch = exports.getBatchesBySupplier = void 0;
+const prismaService_1 = require("../services/prismaService");
+// Obtener todos los lotes (productos) de un proveedor
+const getBatchesBySupplier = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    try {
+        const { supplierId } = req.params;
+        const page = parseInt(req.query.page || '1');
+        const limit = parseInt(req.query.limit || '50');
+        const result = yield prismaService_1.databaseService.getProducts({
+            supplierId: parseInt(supplierId),
+            page,
+            limit
+        });
+        res.json({
+            success: true,
+            batches: result.products,
+            total: result.pagination.total,
+            page: result.pagination.currentPage,
+            limit
+        });
+    }
+    catch (error) {
+        console.error('Error al obtener lotes por proveedor:', error);
+        res.status(500).json({
+            success: false,
+            message: 'Error interno del servidor'
+        });
+    }
+});
+exports.getBatchesBySupplier = getBatchesBySupplier;
+// Crear un nuevo lote (producto) para un proveedor
+const createBatch = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    try {
+        const { supplierId } = req.params;
+        const batchData = Object.assign(Object.assign({}, req.body), { supplierId: parseInt(supplierId) });
+        // Validaciones básicas
+        if (!batchData.title || !batchData.price || !batchData.categoryId) {
+            return res.status(400).json({
+                success: false,
+                message: 'Título, precio y categoría son requeridos'
+            });
+        }
+        const newBatch = yield prismaService_1.databaseService.createProduct(batchData);
+        res.status(201).json({
+            success: true,
+            message: 'Lote creado exitosamente',
+            data: newBatch
+        });
+    }
+    catch (error) {
+        console.error('Error al crear lote:', error);
+        res.status(500).json({
+            success: false,
+            message: 'Error interno del servidor'
+        });
+    }
+});
+exports.createBatch = createBatch;

--- a/dist/routes/index.js
+++ b/dist/routes/index.js
@@ -11,6 +11,7 @@ const authRoutes_1 = __importDefault(require("./authRoutes"));
 const categoryRoutes_1 = __importDefault(require("./categoryRoutes"));
 const rfqRoutes_1 = __importDefault(require("./rfqRoutes"));
 const freightRoutes_1 = __importDefault(require("./freightRoutes"));
+const supplierRoutes_1 = __importDefault(require("./supplierRoutes"));
 const router = (0, express_1.Router)();
 // Rutas de la API
 router.use('/auth', authRoutes_1.default);
@@ -20,6 +21,7 @@ router.use('/cart', cartRoutes_1.default);
 router.use('/orders', orderRoutes_1.default);
 router.use('/rfq', rfqRoutes_1.default);
 router.use('/freight', freightRoutes_1.default);
+router.use('/suppliers', supplierRoutes_1.default);
 // Ruta de prueba
 router.get('/test', (req, res) => {
     res.json({

--- a/dist/routes/supplierRoutes.js
+++ b/dist/routes/supplierRoutes.js
@@ -1,0 +1,10 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const express_1 = require("express");
+const supplierBatchController_1 = require("../controllers/supplierBatchController");
+const router = (0, express_1.Router)();
+// Obtener todos los lotes de un proveedor
+router.get('/:supplierId/batches', supplierBatchController_1.getBatchesBySupplier);
+// Crear un nuevo lote para un proveedor
+router.post('/:supplierId/batches', supplierBatchController_1.createBatch);
+exports.default = router;

--- a/src/controllers/supplierBatchController.ts
+++ b/src/controllers/supplierBatchController.ts
@@ -1,0 +1,61 @@
+import { Request, Response } from 'express';
+import { databaseService } from '../services/prismaService';
+
+// Obtener todos los lotes (productos) de un proveedor
+export const getBatchesBySupplier = async (req: Request, res: Response) => {
+  try {
+    const { supplierId } = req.params;
+    const page = parseInt((req.query.page as string) || '1');
+    const limit = parseInt((req.query.limit as string) || '50');
+
+    const result = await databaseService.getProducts({
+      supplierId: parseInt(supplierId),
+      page,
+      limit
+    });
+
+    res.json({
+      success: true,
+      batches: result.products,
+      total: result.pagination.total,
+      page: result.pagination.currentPage,
+      limit
+    });
+  } catch (error: any) {
+    console.error('Error al obtener lotes por proveedor:', error);
+    res.status(500).json({
+      success: false,
+      message: 'Error interno del servidor'
+    });
+  }
+};
+
+// Crear un nuevo lote (producto) para un proveedor
+export const createBatch = async (req: Request, res: Response) => {
+  try {
+    const { supplierId } = req.params;
+    const batchData = { ...req.body, supplierId: parseInt(supplierId) };
+
+    // Validaciones básicas
+    if (!batchData.title || !batchData.price || !batchData.categoryId) {
+      return res.status(400).json({
+        success: false,
+        message: 'Título, precio y categoría son requeridos'
+      });
+    }
+
+    const newBatch = await databaseService.createProduct(batchData);
+
+    res.status(201).json({
+      success: true,
+      message: 'Lote creado exitosamente',
+      data: newBatch
+    });
+  } catch (error: any) {
+    console.error('Error al crear lote:', error);
+    res.status(500).json({
+      success: false,
+      message: 'Error interno del servidor'
+    });
+  }
+};

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -6,6 +6,7 @@ import authRoutes from './authRoutes';
 import categoryRoutes from './categoryRoutes';
 import rfqRoutes from './rfqRoutes';
 import freightRoutes from './freightRoutes';
+import supplierRoutes from './supplierRoutes';
 
 const router = Router();
 
@@ -17,10 +18,11 @@ router.use('/cart', cartRoutes);
 router.use('/orders', orderRoutes);
 router.use('/rfq', rfqRoutes);
 router.use('/freight', freightRoutes);
+router.use('/suppliers', supplierRoutes);
 
 // Ruta de prueba
 router.get('/test', (req, res) => {
-  res.json({ 
+  res.json({
     message: 'API funcionando correctamente',
     timestamp: new Date().toISOString()
   });

--- a/src/routes/supplierRoutes.ts
+++ b/src/routes/supplierRoutes.ts
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+import { getBatchesBySupplier, createBatch } from '../controllers/supplierBatchController';
+
+const router = Router();
+
+// Obtener todos los lotes de un proveedor
+router.get('/:supplierId/batches', getBatchesBySupplier);
+
+// Crear un nuevo lote para un proveedor
+router.post('/:supplierId/batches', createBatch);
+
+export default router;


### PR DESCRIPTION
## Summary
- implement controller to create and list supplier batches
- expose new routes under `/suppliers`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build` *(fails due to missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6887c5a2031883299268d6e6516b841f